### PR TITLE
Deduct charge from stabilize ability

### DIFF
--- a/StabilizeMe/Src/StabilizeMe/Classes/X2Ability_StabilizeMedkitOwnerAbility.uc
+++ b/StabilizeMe/Src/StabilizeMe/Classes/X2Ability_StabilizeMedkitOwnerAbility.uc
@@ -75,10 +75,74 @@ static function X2AbilityTemplate AddStabilizeMedkitOwnerAbility()
 
 	Template.ActivationSpeech = 'StabilizingAlly';
 
-	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	Template.BuildNewGameStateFn = StabilizeMedkitOwner_BuildGameState;
 	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
 	
 	`log("->(StabilizeMe) AddStabilizeMedkitOwnerAbility has been run.");
 
 	return Template;
+}
+
+static function XComGameState StabilizeMedkitOwner_BuildGameState(XComGameStateContext Context)
+{
+	local XComGameState NewGameState;
+	local XComGameStateContext_Ability AbilityContext;
+	local XComGameState_Unit Target;
+	local XComGameState_Ability AbilityState, UpdatedAbility;
+	local XComGameState_Item Item;
+
+	NewGameState = `XCOMHISTORY.CreateNewGameState(true, Context);
+	// usual ability handling
+	TypicalAbility_FillOutGameState(NewGameState);
+
+	// deduct an ability charge from the target, on the same ability that made StabilizeMedkitOwner available
+	AbilityContext = XComGameStateContext_Ability(Context);
+	Target = XComGameState_Unit(NewGameState.GetGameStateForObjectID(AbilityContext.InputContext.PrimaryTarget.ObjectID));
+	AbilityState = class'X2Condition_StabilizeMedkitOwner'.static.CheckForMedkit(Target);
+
+	if(AbilityState != none && AbilityState.GetCharges() > 0)
+	{
+		// try to get the ability state from the NewGameState
+		// otherwise create and add it
+		UpdatedAbility = XComGameState_Ability(NewGameState.GetGameStateForObjectID(AbilityState.ObjectID));
+		if(UpdatedAbility == none)
+		{
+			UpdatedAbility = XComGameState_Ability(NewGameState.CreateStateObject(AbilityState.class, AbilityState.ObjectID));
+			NewGameState.AddStateObject(UpdatedAbility);
+		}
+
+
+		// remove 1 charge
+
+		// if the ability uses ammo as charges,
+		// deduct the amount of ammo that would be consumed from the source item
+		if(UpdatedAbility.GetMyTemplate().bUseAmmoAsChargesForHUD)
+		{
+			if (UpdatedAbility.SourceAmmo.ObjectID > 0)
+			{
+				Item = XComGameState_Item(`XCOMHISTORY.GetGameStateForObjectID(UpdatedAbility.SourceAmmo.ObjectID));
+			}
+
+			// if SourceAmmo does not exist or coult not be found, try SourceWeapon
+			if(Item == none && UpdatedAbility.SourceWeapon.ObjectID > 0)
+			{
+				Item = XComGameState_Item(`XCOMHISTORY.GetGameStateForObjectID(UpdatedAbility.SourceWeapon.ObjectID));
+			}
+
+			if(Item != none && Item.Ammo > 0)
+			{
+				// update the item and add it to NewGameState
+				Item = XComGameState_Item(NewGameState.CreateStateObject(Item.class, Item.ObjectID));
+				Item.Ammo -= UpdatedAbility.GetMyTemplate().iAmmoAsChargesDivisor;
+				NewGameState.AddStateObject(Item);
+			}
+		}
+
+		// otherwise subtract from iCharges, if not zero and not negative/infinite
+		else if(UpdatedAbility.iCharges > 0)
+		{
+			UpdatedAbility.iCharges -= 1;
+		}
+	}
+	return NewGameState;
 }

--- a/StabilizeMe/Src/StabilizeMe/Classes/X2Condition_StabilizeMedkitOwner.uc
+++ b/StabilizeMe/Src/StabilizeMe/Classes/X2Condition_StabilizeMedkitOwner.uc
@@ -1,7 +1,7 @@
 class X2Condition_StabilizeMedkitOwner extends X2Condition;
 
 // Check for a 'MedikitStabilize' ability in the target unit that the unit would be able to activate.
-static function bool CheckForMedkit(XComGameState_Unit TargetUnit)
+static function XComGameState_Ability CheckForMedkit(XComGameState_Unit TargetUnit)
 {
 	local StateObjectReference AbilityRef;
 	local XComGameState_Ability AbilityState;
@@ -15,7 +15,7 @@ static function bool CheckForMedkit(XComGameState_Unit TargetUnit)
 	
 
 	if (TargetUnit == none)
-		return false;
+		return none;
 
 	History = `XCOMHISTORY;
 
@@ -47,7 +47,7 @@ static function bool CheckForMedkit(XComGameState_Unit TargetUnit)
 						if(AbilityState.GetCharges() > 0)
 						{
 							//`log("->(StabilizeMe) Ability has " $ AbilityState.GetCharges() $ " charges, SUCCESS!");
-							return true;
+							return AbilityState;
 						}
 						//`log("->(StabilizeMe) Ability has " $ AbilityState.GetCharges() $ " charges, FAILURE!");
 					}
@@ -57,7 +57,7 @@ static function bool CheckForMedkit(XComGameState_Unit TargetUnit)
 	}
 
 
-	return false;
+	return none;
 	
 }
 
@@ -69,7 +69,7 @@ event name CallMeetsCondition(XComGameState_BaseObject kTarget)
 	if (TargetUnit == none)
 		return 'AA_NotAUnit';
 
-	if (CheckForMedkit(TargetUnit))
+	if (CheckForMedkit(TargetUnit) != none)
 		return 'AA_Success';
 
 	return 'AA_TargetHasNoStabilizeAbility';


### PR DESCRIPTION
Uses a custom BuildNewGameStateFn to apply charge or ammo costs when StabilizeMedkitOwner fires

fixes an issue where stabilized soldiers who are revived or had a Mindshield equipped will still magically have their medkit available
